### PR TITLE
Disable Ruby 2.3 for Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     - RUBY_VERSION: 25
     - RUBY_VERSION: 24
-    - RUBY_VERSION: 23
     - RUBY_VERSION: _trunk
 
 matrix:


### PR DESCRIPTION
 - https://github.com/metanorma/ietfbib/issues/13
 - remove ruby 2.3 support because of https://github.com/metanorma/isobib/issues/39