### PR TITLE
Harden build_rfc_abstract for issue #128

### DIFF
--- a/lib/relaton/ietf/rfc/entry.rb
+++ b/lib/relaton/ietf/rfc/entry.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cgi"
 require_relative "rfc_index_namespace"
 require_relative "is_also"
 require_relative "author"
@@ -317,7 +318,7 @@ module Relaton
         def build_rfc_abstract
           return [] unless abstract&.p&.any?
 
-          content = abstract.p.map { |para| "<p>#{para.strip}</p>" }.join
+          content = abstract.p.map { |para| "<p>#{CGI.escapeHTML(para.strip)}</p>" }.join
           [Bib::Abstract.new(content: content, language: "en", script: "Latn")]
         end
 

--- a/spec/fixtures/from-bibxm-ids.xml
+++ b/spec/fixtures/from-bibxm-ids.xml
@@ -12,7 +12,7 @@
     <person>
       <name>
         <forename language="en" script="Latn">Predrag</forename>
-        <forename language="en" script="Latn" initial="P"></forename>
+        <forename language="en" script="Latn" initial="P"/>
         <formatted-initials language="en">P.</formatted-initials>
         <surname language="en">Pale</surname>
         <completename language="en">Predrag Pale</completename>
@@ -24,7 +24,7 @@
     <person>
       <name>
         <forename language="en" script="Latn">Kristijan</forename>
-        <forename language="en" script="Latn" initial="K"></forename>
+        <forename language="en" script="Latn" initial="K"/>
         <formatted-initials language="en">K.</formatted-initials>
         <surname language="en">Cerovski</surname>
         <completename language="en">Kristijan Cerovski</completename>
@@ -33,14 +33,14 @@
   </contributor>
   <language>en</language>
   <script>Latn</script>
-  <abstract language="en" script="Latn">   This memo presents a proposal for an efficient and simple way of
-   forming email addresses.  The goal is to achieve easier, more
-   productive communication between email users, in particular by aking
-   addresses intuitive and thus easy to remember, or guess-enabled on
-   material-world data about the correspondent, as well as independent
-   from technical or organizational specifics of email services.
-
-	 </abstract>
+  <abstract language="en" script="Latn">
+    <p>This memo presents a proposal for an efficient and simple way of 
+   forming email addresses.  The goal is to achieve easier, more 
+   productive communication between email users, in particular by aking 
+   addresses intuitive and thus easy to remember, or guess-enabled on 
+   material-world data about the correspondent, as well as independent 
+   from technical or organizational specifics of email services.</p>
+  </abstract>
   <series type="main">
     <title language="en" script="Latn">Internet-Draft</title>
     <number>draft--pale-email-00</number>

--- a/spec/fixtures/rfc_xml.xml
+++ b/spec/fixtures/rfc_xml.xml
@@ -18,8 +18,8 @@
     <person>
       <name>
         <forename language="en" script="Latn">Christopher</forename>
-        <forename language="en" script="Latn" initial="C"></forename>
-        <forename language="en" script="Latn" initial="C"></forename>
+        <forename language="en" script="Latn" initial="C"/>
+        <forename language="en" script="Latn" initial="C"/>
         <formatted-initials language="en">C.C.</formatted-initials>
         <surname language="en">Celi</surname>
         <completename language="en">Christopher Celi</completename>
@@ -59,8 +59,10 @@
   </contributor>
   <language>en</language>
   <script>Latn</script>
-  <abstract language="en" script="Latn">This document defines the JSON schema for using SHA1 and SHA2 with the ACVP
-				specification.</abstract>
+  <abstract language="en" script="Latn">
+    <p>This document defines the JSON schema for using SHA1 and SHA2 with the ACVP
+				specification.</p>
+  </abstract>
   <keyword>
     <vocab language="en" script="Latn">acvp</vocab>
   </keyword>

--- a/spec/relaton/ietf/rfc/index_entry_spec.rb
+++ b/spec/relaton/ietf/rfc/index_entry_spec.rb
@@ -396,6 +396,23 @@ RSpec.describe Relaton::Ietf::Rfc::Entry do
       expect(item.abstract.first.language).to eq "en"
     end
 
+    it "escapes bare angle brackets inside paragraph text" do
+      xml = <<~XML
+        <rfc-entry xmlns="https://www.rfc-editor.org/rfc-index">
+          <doc-id>RFC0001</doc-id>
+          <title>Test</title>
+          <current-status>PROPOSED STANDARD</current-status>
+          <publication-status>PROPOSED STANDARD</publication-status>
+          <stream>IETF</stream>
+          <abstract><p>See &lt;mailto:x@y&gt; for details.</p></abstract>
+        </rfc-entry>
+      XML
+      entry = Relaton::Ietf::Rfc::Entry.from_xml(xml)
+      built = entry.to_item
+      expect(built.abstract.first.content).to eq("<p>See &lt;mailto:x@y&gt; for details.</p>")
+      expect { built.to_xml }.not_to raise_error
+    end
+
     it "creates correct relations" do
       obsoleted = item.relation.select { |r| r.type == "obsoletedBy" }
       expect(obsoleted.size).to eq 2


### PR DESCRIPTION
## Summary
- `Rfc::Entry#build_rfc_abstract` now `CGI.escapeHTML`s the inner paragraph text inside `<p>...</p>`, mirroring the relaton-bib 2.1.1 fix on the BibXML side.
- Refreshes `spec/fixtures/from-bibxm-ids.xml` and `spec/fixtures/rfc_xml.xml` to reflect relaton-bib 2.1.1 wrapping abstract content in `<p>...</p>` and stripping outer whitespace.
- Adds a spec asserting bare `<mailto:...>` inside an rfc-index `<abstract><p>` is escaped to `&lt;mailto:...&gt;` and `to_xml` does not raise.

## Why
Companion to relaton/relaton-bib#111. The relaton-bib release fixes the BibXML converter so newly generated I-D YAML cannot contain bare `<` characters in `abstract.content`. This change applies the same hardening to the RFC-index code path so a future rfc-editor feed change can't reintroduce the `Moxml::ParseError` reported in issue #128.

## Test plan
- [x] `bundle exec rspec` — 276 examples, 0 failures
- [ ] After merge, regenerate v2 data branches via `Relaton::Ietf::DataFetcher` to unblock users on 2.1.1

Fixes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)